### PR TITLE
Ensure the ONBUILD Dockerfiles have the epel repo

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -44,6 +44,7 @@ RUN set -ex && \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done && \
   INSTALL_PKGS="bzip2 nss_wrapper" && \
+  yum -y install epel-release && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
   yum clean all -y && \

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ If you are interested in developing against SCL-based Node.js releases, try [sti
 [![docker hub stats](http://dockeri.co/image/bucharestgold/centos7-s2i-nodejs)](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/)
 -->
 
-<!--
 [![](https://images.microbadger.com/badges/image/bucharestgold/centos7-s2i-nodejs.svg)](https://microbadger.com/images/bucharestgold/centos7-s2i-nodejs "Get your own image badge on microbadger.com")
--->
 
 For more information about using these images with OpenShift, please see the
 official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/nodejs.html).

--- a/test/run
+++ b/test/run
@@ -48,13 +48,6 @@ prepare() {
     echo "ERROR: The image ${IMAGE_TAG} must exist before this script is executed."
     exit 1
   fi
-  # TODO: STI build require the application is a valid 'GIT' repository, we
-  # should remove this restriction in the future when a file:// is used.
-  pushd ${test_dir}/test-app >/dev/null
-  git init
-  git config user.email "build@localhost" && git config user.name "builder"
-  git add -A && git commit --no-gpg-sign -m "Sample commit"
-  popd >/dev/null
 }
 
 run_test_application() {
@@ -71,7 +64,6 @@ cleanup() {
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi -f ${IMAGE_NAME}-testapp
   fi
-  rm -rf ${test_dir}/test-app/.git
   cids=`ls -1 *.cid 2>/dev/null | wc -l`
   if [ $cids != 0 ]
   then


### PR DESCRIPTION
This allows installation of nss_wrapper. Also, `s2i` no longer requires a local source directory to be a git repository. So we don't need to bother with that in our code.