### PR TITLE
Build optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 before_script:
-  - sudo apt install python-pip
+  # - sudo apt install python-pip
   - pip install docker-squash
   - wget https://github.com/openshift/source-to-image/releases/download/v1.1.4/source-to-image-1.1.4-870b273-linux-amd64.tar.gz
   - tar xvzOf source-to-image-1.1.4-870b273-linux-amd64.tar.gz > s2i.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM openshift/base-centos7
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
 
-MAINTAINER Lance Ball <lball@redhat.com>
-
 EXPOSE 8080
 
 # This image will be initialized with "npm run $NPM_RUN"
@@ -26,7 +24,8 @@ LABEL io.k8s.description="Platform for building and running Node.js applications
       io.k8s.display-name="Node.js $NODE_VERSION" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,nodejs,nodejs-$NODE_VERSION" \
-      com.redhat.deployments-dir="/opt/app-root/src"
+      com.redhat.deployments-dir="/opt/app-root/src" \
+      maintainer="Lance Ball <lball@redhat.com>"
 
 # Download and install a binary from nodejs.org
 # Add the gpg keys listed at https://github.com/nodejs/node

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -3,8 +3,6 @@ FROM openshift/base-centos7
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
 
-MAINTAINER Lance Ball <lball@redhat.com>
-
 EXPOSE 8080
 
 # This image will be initialized with "npm run $NPM_RUN"
@@ -26,7 +24,8 @@ LABEL io.k8s.description="Platform for building and running Node.js applications
       io.k8s.display-name="Node.js $NODE_VERSION" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,nodejs,nodejs-$NODE_VERSION" \
-      com.redhat.deployments-dir="/opt/app-root/src"
+      com.redhat.deployments-dir="/opt/app-root/src" \
+      maintainer="Lance Ball <lball@redhat.com>"
 
 # Download and install a binary from nodejs.org
 # Add the gpg keys listed at https://github.com/nodejs/node

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -44,6 +44,7 @@ RUN set -ex && \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done && \
   INSTALL_PKGS="bzip2 nss_wrapper" && \
+  yum -y install epel-release && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
   yum clean all -y && \

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ If you are interested in developing against SCL-based Node.js releases, try [sti
 [![docker hub stats](http://dockeri.co/image/bucharestgold/centos7-s2i-nodejs)](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/)
 -->
 
-<!--
 [![](https://images.microbadger.com/badges/image/bucharestgold/centos7-s2i-nodejs.svg)](https://microbadger.com/images/bucharestgold/centos7-s2i-nodejs "Get your own image badge on microbadger.com")
--->
 
 For more information about using these images with OpenShift, please see the
 official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/nodejs.html).

--- a/build/build.sh
+++ b/build/build.sh
@@ -37,7 +37,7 @@ function squash {
   #        compatibility issues
   easy_install -v --user docker_py==1.6.0 docker-squash==1.0.5
   base=$(awk '/^FROM/{print $2}' $1)
-  docker-squash -f $base ${IMAGE_NAME}:${version}
+  docker-squash -f $base ${IMAGE_NAME}:${version} -t ${IMAGE_NAME}:${version}
 }
 
 # Specify a VERSION variable to build a specific nodejs.org release

--- a/test/run
+++ b/test/run
@@ -48,13 +48,6 @@ prepare() {
     echo "ERROR: The image ${IMAGE_TAG} must exist before this script is executed."
     exit 1
   fi
-  # TODO: STI build require the application is a valid 'GIT' repository, we
-  # should remove this restriction in the future when a file:// is used.
-  pushd ${test_dir}/test-app >/dev/null
-  git init
-  git config user.email "build@localhost" && git config user.name "builder"
-  git add -A && git commit --no-gpg-sign -m "Sample commit"
-  popd >/dev/null
 }
 
 run_test_application() {
@@ -71,7 +64,6 @@ cleanup() {
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi -f ${IMAGE_NAME}-testapp
   fi
-  rm -rf ${test_dir}/test-app/.git
   cids=`ls -1 *.cid 2>/dev/null | wc -l`
   if [ $cids != 0 ]
   then


### PR DESCRIPTION
* Ensure the docker image is named and tagged correctly after docker-squash.
* No need for the test code to be a github repo. The s2i tool has removed that requirement.
* Eliminate `MAINTAINER` command in favor of `LABEL maintainer`.
* Ensure ONBUILD images use the epel repo for yum.